### PR TITLE
API Mode inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,10 +85,17 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "ts-jest"
+      ".(ts|tsx)$": "ts-jest"
     },
     "testEnvironment": "node",
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleNameMapper": {
+      "^@/(.*)$": [
+        "<rootDir>/src/$1"
+      ],
+      "^test/(.*)$": [
+        "<rootDir>/test/$1"
+      ]
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,28 +49,27 @@ export class Client {
       logger: console,
     }
 
+    const { apiRoot, mode } = options
+
     // If a single string value was provided for the API root URL, use it for both LIVE and TEST
     // API modes
-    if (typeof options.apiRoot === 'string') {
+    if (typeof apiRoot === 'string') {
       options.apiRoot = {
-        [ApiMode.TEST]: options.apiRoot,
-        [ApiMode.LIVE]: options.apiRoot,
+        [ApiMode.TEST]: apiRoot,
+        [ApiMode.LIVE]: apiRoot,
       }
-    } else if (
-      options.apiRoot &&
-      (!options.apiRoot[ApiMode.TEST] || !options.apiRoot[ApiMode.LIVE])
-    ) {
+    } else if (apiRoot && (!apiRoot[ApiMode.TEST] || !apiRoot[ApiMode.LIVE])) {
       throw new Error(
         'ClientOptions `apiRoot` must be a string or an object with ApiMode values as keys'
       )
     }
 
-    if (!!options.mode && options.mode !== ApiMode.LIVE && options.mode !== ApiMode.TEST) {
+    if (!!mode && mode !== ApiMode.LIVE && mode !== ApiMode.TEST) {
       throw new Error('ClientOptions `mode` must be an ApiMode value')
     }
 
     // Infer API mode from provided API key when it makes sense
-    if (!options.mode && credentials instanceof ApiKeyCredentials) {
+    if (!mode && credentials instanceof ApiKeyCredentials) {
       options.mode = credentials.apiKey.indexOf('_live_', 2) > 0 ? ApiMode.LIVE : ApiMode.TEST
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -104,6 +104,10 @@ export class Client {
   get mode(): ApiMode {
     return this.context.mode
   }
+
+  set mode(mode: ApiMode) {
+    this.context.mode = mode
+  }
 }
 
 export default Client

--- a/src/context.ts
+++ b/src/context.ts
@@ -20,6 +20,10 @@ export class Context {
     return this.config.mode
   }
 
+  set mode(mode: ApiMode) {
+    this.config.mode = mode
+  }
+
   get logger(): Console {
     return this.config.logger
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { ApiRootObject, ClientConfig } from './client'
+import { ClientConfig } from './client'
 import { ApiMode } from './consts'
 import Credentials from './credentials/base'
 
@@ -13,8 +13,7 @@ export class Context {
   }
 
   get apiRoot(): string {
-    // At this point, we *know* config.apiRoot is an ApiRootObject object and not a string
-    return (this.config.apiRoot as ApiRootObject)[this.config.mode].trim()
+    return this.config.apiRoot[this.config.mode].trim()
   }
 
   get mode(): ApiMode {

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,7 @@ export class Context {
   }
 
   get apiRoot(): string {
-    return this.config.apiRoot[this.config.mode].trim()
+    return this.config.apiRoot[this.mode].trim()
   }
 
   get mode(): ApiMode {

--- a/src/credentials/ApiKeyCredentials.ts
+++ b/src/credentials/ApiKeyCredentials.ts
@@ -1,15 +1,15 @@
-import Credentials from "./base";
-import {AxiosRequestConfig} from "axios";
+import Credentials from './base'
+import { AxiosRequestConfig } from 'axios'
 
 export class ApiKeyCredentials implements Credentials {
   public readonly apiKey: string
 
   constructor(apiKey: string) {
     if (!apiKey.trim()) {
-      throw new Error("An API key is required to instantiate a new Client");
+      throw new Error('An API key is required to instantiate a new Client')
     }
 
-    this.apiKey = apiKey;
+    this.apiKey = apiKey
   }
 
   configureCredentials(config: AxiosRequestConfig): AxiosRequestConfig {
@@ -18,11 +18,10 @@ export class ApiKeyCredentials implements Credentials {
       ...config,
       headers: {
         ...config.headers,
-        "Authorization": `Alma-Auth ${this.apiKey}`,
-      }
-    };
+        Authorization: `Alma-Auth ${this.apiKey}`,
+      },
+    }
   }
-
 }
 
-export default ApiKeyCredentials;
+export default ApiKeyCredentials

--- a/src/credentials/ApiKeyCredentials.ts
+++ b/src/credentials/ApiKeyCredentials.ts
@@ -2,7 +2,7 @@ import Credentials from "./base";
 import {AxiosRequestConfig} from "axios";
 
 export class ApiKeyCredentials implements Credentials {
-  private readonly apiKey: string;
+  public readonly apiKey: string
 
   constructor(apiKey: string) {
     if (!apiKey.trim()) {

--- a/src/credentials/MerchantIdCredentials.ts
+++ b/src/credentials/MerchantIdCredentials.ts
@@ -6,7 +6,7 @@ export class MerchantIdCredentials implements Credentials {
 
   constructor(merchantId: string) {
     if (!merchantId.trim()) {
-      throw new Error("An API key is required to instantiate a new Client");
+      throw new Error('A merchant ID is required to instantiate a new Client')
     }
 
     this.merchantId = merchantId;

--- a/src/credentials/MerchantIdCredentials.ts
+++ b/src/credentials/MerchantIdCredentials.ts
@@ -1,15 +1,15 @@
-import Credentials from "./base";
-import {AxiosRequestConfig} from "axios";
+import Credentials from './base'
+import { AxiosRequestConfig } from 'axios'
 
 export class MerchantIdCredentials implements Credentials {
-  private readonly merchantId: string;
+  private readonly merchantId: string
 
   constructor(merchantId: string) {
     if (!merchantId.trim()) {
       throw new Error('A merchant ID is required to instantiate a new Client')
     }
 
-    this.merchantId = merchantId;
+    this.merchantId = merchantId
   }
 
   configureCredentials(config: AxiosRequestConfig): AxiosRequestConfig {
@@ -18,11 +18,10 @@ export class MerchantIdCredentials implements Credentials {
       ...config,
       headers: {
         ...config.headers,
-        "Authorization": `Alma-Merchant-Auth ${this.merchantId}`,
-      }
-    };
+        Authorization: `Alma-Merchant-Auth ${this.merchantId}`,
+      },
+    }
   }
-
 }
 
-export default MerchantIdCredentials;
+export default MerchantIdCredentials

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,14 +1,44 @@
-import { Client } from '../src'
+import { ApiMode, Client } from '../src'
+import { Context } from '../src/context'
+
+import { mocked } from 'ts-jest/utils'
+
+jest.mock('../src/context')
 
 /**
  * Client tests
  */
 describe('API client', () => {
-  it('exposes withApiKey method', () => {
-    expect(Client.withApiKey).toBeTruthy()
+  describe('instantiation', () => {
+    it('exposes withApiKey method', () => {
+      expect(Client.withApiKey).toBeTruthy()
+    })
+
+    it('exposes withMerchantId method', () => {
+      expect(Client.withMerchantId).toBeTruthy()
+    })
   })
 
-  it('exposes withMerchantId method', () => {
-    expect(Client.withMerchantId).toBeTruthy()
+  describe('ClientOptions', () => {
+    const MockedContext = mocked(Context, true)
+
+    beforeEach(() => {
+      // Clear all instances and calls to constructor and all methods:
+      MockedContext.mockClear()
+    })
+
+    it('accepts a string as apiRoot and sets it for both modes', () => {
+      const expectedApiRoot = 'http://api-root.local'
+      Client.withApiKey('sk_test_xxx', { apiRoot: expectedApiRoot })
+
+      const actualApiRoot = MockedContext.mock.calls[0][1].apiRoot
+
+      expect(actualApiRoot).toBeInstanceOf(Object)
+      expect(actualApiRoot).toHaveProperty(ApiMode.LIVE)
+      expect(actualApiRoot).toHaveProperty(ApiMode.TEST)
+
+      expect(actualApiRoot[ApiMode.LIVE]).toBe(expectedApiRoot)
+      expect(actualApiRoot[ApiMode.TEST]).toBe(expectedApiRoot)
+    })
   })
 })

--- a/test/client/mode.test.ts
+++ b/test/client/mode.test.ts
@@ -1,0 +1,43 @@
+import { ApiMode, Client } from '@/index'
+import Context from '@/context'
+
+function buildClient() {
+  return Client.withApiKey('sk_test_xxx')
+}
+
+describe('API client', () => {
+  describe('API mode', () => {
+    it('can be retrieved on the Client instance', () => {
+      const client = buildClient()
+
+      expect(client).toHaveProperty('mode')
+      expect(client.mode).toBe(ApiMode.TEST)
+    })
+
+    it('retrieves it from its context', () => {
+      const spy = jest.spyOn(Context.prototype, 'mode', 'get').mockReturnValue('blah' as ApiMode)
+
+      const client = buildClient()
+      expect(client.mode).toBe('blah')
+
+      spy.mockRestore()
+    })
+
+    it('can be set', () => {
+      const client = buildClient()
+      client.mode = ApiMode.LIVE
+      expect(client.mode).toBe(ApiMode.LIVE)
+    })
+
+    it('sets it on its context', () => {
+      const spy = jest.spyOn(Context.prototype, 'mode', 'set')
+
+      const client = buildClient()
+      client.mode = ApiMode.LIVE
+
+      expect(spy).toHaveBeenCalledWith(ApiMode.LIVE)
+
+      spy.mockRestore()
+    })
+  })
+})

--- a/test/client/options.test.ts
+++ b/test/client/options.test.ts
@@ -1,24 +1,14 @@
-import { ApiMode, Client } from '../src'
-import { Context } from '../src/context'
+import { ApiMode, Client } from '@/index'
+import { Context } from '@/context'
 
 import { mocked } from 'ts-jest/utils'
 
-jest.mock('../src/context')
+jest.mock('@/context')
 
 /**
- * Client tests
+ * ClientOptions / ClientConfig tests
  */
 describe('API client', () => {
-  describe('instantiation', () => {
-    it('exposes withApiKey method', () => {
-      expect(Client.withApiKey).toBeTruthy()
-    })
-
-    it('exposes withMerchantId method', () => {
-      expect(Client.withMerchantId).toBeTruthy()
-    })
-  })
-
   describe('ClientOptions', () => {
     const MockedContext = mocked(Context, true)
 

--- a/test/client/withApiKey.test.ts
+++ b/test/client/withApiKey.test.ts
@@ -37,10 +37,4 @@ describe('API client', () => {
       })
     })
   })
-
-  describe('with a merchant ID', () => {
-    it('exposes withMerchantId method', () => {
-      expect(Client.withMerchantId).toBeInstanceOf(Function)
-    })
-  })
 })

--- a/test/client/withApiKey.test.ts
+++ b/test/client/withApiKey.test.ts
@@ -1,0 +1,46 @@
+import { ApiMode, Client } from '@/index'
+
+import ApiKeyCredentials from '../../src/credentials/ApiKeyCredentials'
+
+/**
+ * Client tests
+ */
+describe('API client', () => {
+  describe('instantiation with an API key', () => {
+    it('exposes withApiKey method', () => {
+      expect(Client.withApiKey).toBeInstanceOf(Function)
+    })
+
+    describe.each([
+      /// expectedMode, apiKey
+      [ApiMode.TEST, 'sk_test_xxx'],
+      [ApiMode.LIVE, 'sk_live_xxx'],
+      ///
+    ])('%s mode inference from "%s" API key', (expectedMode, apiKey) => {
+      it('works with withApiKey', () => {
+        const client = Client.withApiKey(apiKey)
+        expect(client.mode).toBe(expectedMode)
+      })
+
+      it('works with constructor', () => {
+        const client = new Client(new ApiKeyCredentials(apiKey))
+        expect(client.mode).toBe(expectedMode)
+      })
+
+      it('does not override provided mode', () => {
+        const otherMode = {
+          [ApiMode.LIVE]: ApiMode.TEST,
+          [ApiMode.TEST]: ApiMode.LIVE,
+        }
+        const client = Client.withApiKey(apiKey, { mode: otherMode[expectedMode] })
+        expect(client.mode).toBe(otherMode[expectedMode])
+      })
+    })
+  })
+
+  describe('with a merchant ID', () => {
+    it('exposes withMerchantId method', () => {
+      expect(Client.withMerchantId).toBeInstanceOf(Function)
+    })
+  })
+})

--- a/test/client/withMerchantId.test.ts
+++ b/test/client/withMerchantId.test.ts
@@ -1,0 +1,12 @@
+import { Client } from '@/index'
+
+/**
+ * Client tests
+ */
+describe('API client', () => {
+  describe('instantiation with a merchant ID', () => {
+    it('exposes withMerchantId method', () => {
+      expect(Client.withMerchantId).toBeInstanceOf(Function)
+    })
+  })
+})

--- a/test/context/context.test.ts
+++ b/test/context/context.test.ts
@@ -1,0 +1,68 @@
+import { ApiMode } from '@/index'
+import { Context } from '@/context'
+import MerchantIdCredentials from '@/credentials/MerchantIdCredentials'
+
+describe('Context', () => {
+  let context: Context
+  const testConfig = {
+    apiRoot: {
+      [ApiMode.LIVE]: 'https://live.local/',
+      [ApiMode.TEST]: 'https://test.local',
+    },
+    mode: ApiMode.TEST,
+    logger: console,
+  }
+
+  beforeEach(() => {
+    context = new Context(new MerchantIdCredentials('xxx'), testConfig)
+  })
+
+  it('returns mode from initial config', () => {
+    expect(context.mode).toBe(testConfig.mode)
+  })
+
+  it('can set a different mode', () => {
+    context.mode = ApiMode.LIVE
+    expect(context.mode).toBe(ApiMode.LIVE)
+  })
+
+  describe.each([
+    /// expectedRootMode, apiMode
+    [ApiMode.LIVE, ApiMode.LIVE],
+    [ApiMode.TEST, ApiMode.TEST],
+    ///
+  ])('returns %s apiRoot for %s mode', (expectedRootMode, apiMode) => {
+    it('works', () => {
+      context.mode = apiMode
+      expect(context.apiRoot).toBe(testConfig.apiRoot[expectedRootMode])
+    })
+  })
+
+  it('returns the logger object from provided config', () => {
+    expect(context.logger).toBe(testConfig.logger)
+  })
+
+  describe.each([
+    /// expectedUrl, path, mode
+    ['https://live.local/path/to/endpoint', '/path/to/endpoint', ApiMode.LIVE],
+    ['https://live.local/path/to/endpoint', 'path/to/endpoint', ApiMode.LIVE],
+    ['https://test.local/path/to/endpoint', '/path/to/endpoint', ApiMode.TEST],
+    ['https://test.local/path/to/endpoint', 'path/to/endpoint', ApiMode.TEST],
+    ///
+  ])(
+    'returns URL "%s" for path "%s" with mode %s',
+    (expectedUrl: string, path: string, mode: ApiMode) => {
+      it('works', () => {
+        context.mode = mode
+        expect(context.urlFor(path)).toBe(expectedUrl)
+      })
+    }
+  )
+
+  it('handles user-agent components', () => {
+    context.addUserAgentComponent('JavaScript')
+    context.addUserAgentComponent('API Client tests', '42')
+
+    expect(context.userAgentString).toBe('API Client tests/42; JavaScript')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "outDir": "dist/lib",
     "typeRoots": [
       "node_modules/@types"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     "src"


### PR DESCRIPTION
Automatically infer the client's API mode when it makes sense, which is when both:
- an API key is being used as credentials
- no API mode has been explicitly given in the client's options

This allows writing `const alma = Client.withApiKey('sk_test_xxx')` instead of `const alma = Client.withApiKey('sk_test_xxx', {mode: ApiMode.TEST})`.

When using a merchant ID as credentials, it still makes sense to have an option to set the API mode manually though, as the mode cannot be inferred from the ID.
Note that `apiRoot` does not disapear either: although there's a single API root possibly usable for a given API key (since it targets either the test or live environment), a merchant ID can however be used on either environment, so it makes sense to be able to define both roots and switch from one to the other.

To better support this, the PR also adds a `mode` property getter and setter on the `Client` class directly:

```ts
const alma = Client.withMerchantID(merchantID, { mode: ApiMode.TEST })
alma.mode = ApiMode.LIVE
```

I've also started adding some test cases for all this!