### PR TITLE
fix: releases are now managed by release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+name-template: 'v$NEXT_MAJOR_VERSION'
+tag-template: 'v$NEXT_MAJOR_VERSION'
+version-template: '$MAJOR'
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ### Contributors
+
+  $CONTRIBUTORS
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'type: feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type: bugfix'
+  - title: '📝 Documentation'
+    labels: 'type: docs'
+  - title: '🔐 Security'
+    labels:
+      - 'type: security'
+  - title: '⚙️ Internal Changes'
+    labels:
+      - 'type: chore'
+      - 'type: ci'
+      - 'type: perf'
+      - 'type: refactor'
+      - 'type: test'
+
+change-template: '- $TITLE (#$NUMBER • @$AUTHOR)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+env:
+  BUILD_VERSION: build-${{ github.run_number }}
+
 jobs:
   tests:
     name: Test
@@ -46,12 +49,10 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Release
+      - uses: release-drafter/release-drafter@v5
+        with:
+          name: ${{ env.BUILD_VERSION }}
+          tag: ${{ env.BUILD_VERSION }}
+          version: ${{ env.BUILD_VERSION }}
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions
-          GIT_AUTHOR_EMAIL: 44210433+github-actions@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions
-          GIT_COMMITTER_EMAIL: 44210433+github-actions@users.noreply.github.com
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR is a proposal to move to `release-drafter` as `main` did, to avoid to push to master to create a new release.
It's just a ripoff of what has been done in `main`, you may want something slightly different. If so, just shoot :)